### PR TITLE
Share ibis con

### DIFF
--- a/intake_omnisci/__init__.py
+++ b/intake_omnisci/__init__.py
@@ -1,5 +1,6 @@
 __version__ = "0.1.0"
 
+import intake
 from .catalog import OmniSciCatalog
 from .source import OmniSciSource
 

--- a/intake_omnisci/catalog.py
+++ b/intake_omnisci/catalog.py
@@ -72,9 +72,24 @@ class OmniSciCatalog(Catalog):
         """
         connection = pymapd.connect(**self._init_args)
         self._entries = {}
+        ibis_con = None
+        try:
+            import ibis.omniscidb
+            ibis_con = ibis.omniscidb.connect(
+                uri=self._init_args['uri'],
+                user=self._init_args['user'],
+                password=self._init_args['password'],
+                host=self._init_args['host'],
+                port=self._init_args['port'],
+                protocol=self._init_args['protocol'],
+                database=self._init_args['dbname'],
+            )
+        except ImportError:
+            pass
         for table in connection.get_tables():
             description = "SQL table %s from %s" % (table, str(self))
             args = {key: value for key, value in self._init_args.items() if value}
+            args['ibis_con'] = ibis_con
             args["sql_expr"] = table
             e = LocalCatalogEntry(table, description, "omnisci", True, args)
             self._entries[table] = e

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ setup(
     include_package_data=True,
     entry_points={
         "intake.drivers": [
-            "omnisci = intake_omnisci:OmniSciSource",
-            "omnisci_cat = intake_omnisci:OmniSciCatalog",
+            "omnisci = intake_omnisci.source:OmniSciSource",
+            "omnisci_cat = intake_omnisci.catalog:OmniSciCatalog",
         ]
     },
     install_requires=requires,


### PR DESCRIPTION
This shares an ibis connection when multiple tables are pulled out of the same SQL catalog. This is important because it allows for joins across different tables within the same database drawn from the catalog.